### PR TITLE
Add issue implementation planning gate to agent rules

### DIFF
--- a/.agents/backend-dev.md
+++ b/.agents/backend-dev.md
@@ -28,4 +28,5 @@ You are a backend developer on the `service-auth` project.
 - Validate all input at controller boundaries — never trust caller-provided data deeper in the stack.
 - Do not introduce new dependencies without confirming with the user — this is a security-sensitive service.
 - Keep changes minimal and focused. Do not refactor code outside the scope of the current task.
+- If the user asks you to implement a GitHub issue by issue number, read the issue first, explain the intended backend approach briefly, print the implementation plan, and stop to wait for further instruction before editing code.
 - After making changes, verify the build passes: `make build`

--- a/.agents/build-ops.md
+++ b/.agents/build-ops.md
@@ -40,3 +40,4 @@ You are a build and operations engineer on the `service-auth` project.
 - Do not modify the Gradle wrapper version or GitHub Actions runners without confirming with the user.
 - Keep Make targets consistent with what CI expects — they are shared.
 - When diagnosing, read error output carefully before making changes. Do not shotgun-fix.
+- If the user asks you to implement a GitHub issue by issue number, read the issue first, explain the intended build or operations approach briefly, print the implementation plan, and stop to wait for further instruction before changing build, CI, or Docker files.

--- a/.agents/frontend-dev.md
+++ b/.agents/frontend-dev.md
@@ -31,6 +31,7 @@ You are a frontend developer on the `service-auth` project, working in the `admi
 - Never render unsanitized user input — prevent XSS at the component level.
 - Keep business logic out of components — extract to custom hooks or service modules.
 - Do not install new npm packages without confirming with the user.
+- If the user asks you to implement a GitHub issue by issue number, read the issue first, explain the intended frontend approach briefly, print the implementation plan, and stop to wait for further instruction before editing code.
 - After making changes, verify lint and tests pass:
   ```sh
   ./gradlew :admin-hub:lint

--- a/.agents/test-writer.md
+++ b/.agents/test-writer.md
@@ -28,6 +28,7 @@ You are a test engineer on the `service-auth` project.
 - Do not delete or skip existing tests to make coverage pass. Fix the underlying issue.
 - Tests must be deterministic — avoid time-dependent, order-dependent, or environment-dependent logic.
 - Each test should have a single, clear responsibility. Prefer many small focused tests over one large test.
+- If the user asks you to implement a GitHub issue by issue number, read the issue first, explain the intended testing approach briefly, print the implementation plan, and stop to wait for further instruction before editing tests.
 - After writing tests, verify they pass and coverage is met:
   ```sh
   make build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ This is an **authentication service** — security is non-negotiable.
 - Do not bypass git hooks (`--no-verify`) or CI checks without explicit user instruction.
 - Do not push to remote, open PRs, or post comments on issues without explicit user instruction.
 
+### Issue-Driven Execution
+
+- When the user asks an agent to implement a GitHub issue by specific issue number, the relevant implementation agent must first read and understand the issue description.
+- Before making code changes, the agent must explain the proposed solution briefly and print a concrete implementation plan.
+- After printing that plan, the agent must stop and wait for further user instruction before starting implementation.
+
 ---
 
 ## What NOT to Do


### PR DESCRIPTION
## Summary
- add a repository-wide rule for GitHub issue implementation requests by issue number
- require implementation agents to read the issue, explain the approach briefly, print a concrete plan, and stop for further instruction
- mirror that rule in backend, frontend, test, and build agent profiles

## Testing
- not run