### PR TITLE
Allow issue work to continue through PR creation

### DIFF
--- a/.agents/backend-dev.md
+++ b/.agents/backend-dev.md
@@ -33,4 +33,5 @@ You are a backend developer on the `service-auth` project.
 - Keep backend tests deterministic and readable. Prefer small focused Spock specifications over large mixed-behavior tests.
 - Keep changes minimal and focused. Do not refactor code outside the scope of the current task.
 - If the user asks you to implement a GitHub issue by issue number, read the issue first, explain the intended backend approach briefly, print the implementation plan, and stop to wait for further instruction before editing code.
+- Once the user tells you to proceed, you may implement the issue, stage and commit the changes, push the branch, and create the PR without another stop. Stop only after the PR is created.
 - After making changes, verify the build passes: `make build`

--- a/.agents/build-ops.md
+++ b/.agents/build-ops.md
@@ -41,3 +41,4 @@ You are a build and operations engineer on the `service-auth` project.
 - Keep Make targets consistent with what CI expects — they are shared.
 - When diagnosing, read error output carefully before making changes. Do not shotgun-fix.
 - If the user asks you to implement a GitHub issue by issue number, read the issue first, explain the intended build or operations approach briefly, print the implementation plan, and stop to wait for further instruction before changing build, CI, or Docker files.
+- Once the user tells you to proceed, you may implement the issue, stage and commit the changes, push the branch, and create the PR without another stop. Stop only after the PR is created.

--- a/.agents/frontend-dev.md
+++ b/.agents/frontend-dev.md
@@ -36,6 +36,7 @@ You are a frontend developer on the `service-auth` project, working in the `admi
 - Prefer TDD when the task can be approached incrementally: start with a failing or missing test, implement the change, then make the test pass.
 - Keep frontend tests deterministic and behavior-focused. Prefer focused Vitest and React Testing Library coverage over broad brittle tests.
 - If the user asks you to implement a GitHub issue by issue number, read the issue first, explain the intended frontend approach briefly, print the implementation plan, and stop to wait for further instruction before editing code.
+- Once the user tells you to proceed, you may implement the issue, stage and commit the changes, push the branch, and create the PR without another stop. Stop only after the PR is created.
 - After making changes, verify lint and tests pass:
   ```sh
   ./gradlew :admin-hub:lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ This is an **authentication service** — security is non-negotiable.
 - When the user asks an agent to implement a GitHub issue by specific issue number, the relevant implementation agent must first read and understand the issue description.
 - Before making code changes, the agent must explain the proposed solution briefly and print a concrete implementation plan.
 - After printing that plan, the agent must stop and wait for further user instruction before starting implementation.
+- Once the user confirms implementation should proceed, the agent does not need to stop again for staging changes, committing local changes, pushing the branch, or creating the PR.
+- After the PR is created, the agent must stop and wait for further user instruction before taking additional actions such as merging, editing the PR, or switching branches.
 
 ---
 


### PR DESCRIPTION
## Summary
- update issue-driven execution rules so agents still stop for an initial implementation plan
- allow implementation agents to continue through commit, push, and PR creation once the user says to proceed
- require agents to stop only after the PR is created

## Testing
- not run