### PR TITLE
Add PR build workflow for issue #7

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,36 @@
+name: PR Build
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  build:
+    name: build
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: gradle
+
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: admin-hub/package-lock.json
+
+      - name: Build project
+        run: make build


### PR DESCRIPTION
Closes #7

## Summary
- add a GitHub Actions workflow that runs make build on pull request events
- provision Java 25 and Node 24 in CI to match the local toolchain
- expose a stable PR build check that can be required by branch protection

## Testing
- make build